### PR TITLE
Sort user names on Users#index

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,28 @@
-  class UsersController < InheritedResources::Base 
-    load_and_authorize_resource
+class UsersController < InheritedResources::Base 
+  load_and_authorize_resource
+  skip_load_and_authorize_resource only: :index
 
-    def update 
-      add_right = params[:user][:add_right]
-      unless add_right[:series].empty?
-        UserAccess.create(
-          :user_id=>@user.id,
-          :series_id=>add_right[:series],
-          :granted_by_id=>current_user.id)
+  def index
+    authorize! :read, @users
+    super
+  end
+
+  def update 
+    add_right = params[:user][:add_right]
+    unless add_right[:series].empty?
+      UserAccess.create(
+        :user_id=>@user.id,
+        :series_id=>add_right[:series],
+        :granted_by_id=>current_user.id)
     end
     params[:user].delete(:add_right)
-    
+
     update! { edit_user_path(@user) }
+  end
+
+protected
+
+  def collection
+    @users ||= end_of_association_chain.order("first_name asc, last_name asc")
   end
 end


### PR DESCRIPTION
Skipping load_and_authorize_resource for index and overloading the action is a
workaround for a known issue with CanCan and InheritedResources. See
https://github.com/ryanb/cancan/wiki/Inherited-Resources.
