### PR TITLE
Lagar rättningsverifikat

### DIFF
--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -166,7 +166,7 @@ Attesterat av: #{authorized_by_to_s}
     rows = voucher_rows
     rows.reject!(&:canceled?) unless options[:canceled]
     rows.map do |old|
-      vr = old.clone
+      vr = old.dup
       vr.sum *= -1
       vr
     end


### PR DESCRIPTION
Det gick inte att skapa rättningsverifikat eftersom id på voucher_rows från inverted_rows var samma som orginalraden (vilket ledde till att den försökte uppdatera dem istället för att skapa nya).